### PR TITLE
fix issue 45. Implements 2nd floating point difference model. 

### DIFF
--- a/texttestlib/default/__init__.py
+++ b/texttestlib/default/__init__.py
@@ -1283,6 +1283,7 @@ class Config:
                              "Mapping of result files to which order they should be shown in the text info window.")
         app.setConfigDefault("floating_point_tolerance", { "default" : 0.0 }, "Which tolerance to apply when comparing floating point values in output")
         app.setConfigDefault("relative_float_tolerance", { "default" : 0.0 }, "Which relative tolerance to apply when comparing floating point values")
+        app.setConfigDefault("float_diff_model", { "default" : 0 }, "Which model to apply when comparing floating point values")
 
         app.setConfigDefault("collate_file", self.getDefaultCollations(), "Mapping of result file names to paths to collect them from")
         app.setConfigDefault("collate_script", self.getDefaultCollateScripts(), "Mapping of result file names to scripts which turn them into suitable text")

--- a/texttestlib/default/fpdiff.py
+++ b/texttestlib/default/fpdiff.py
@@ -1,12 +1,13 @@
 #!/usr/bin/env python2
-import sys, difflib
+import sys, difflib, re
+
 
 def _getNumberAt(l, pos):
     start = pos
     eSeen = False
     dotSeen = False
-    while start > 0 and l[start-1] in "1234567890.eE-":
-        if l[start-1] in "eE":
+    while start > 0 and l[start-1] in "1234567890.eEdD-+":
+        if l[start-1] in "eEdD":
             if eSeen:
                 break
             eSeen = True
@@ -16,8 +17,8 @@ def _getNumberAt(l, pos):
             dotSeen = True
         start -= 1
     end = pos
-    while end < len(l) and l[end] in "1234567890.eE-":
-        if l[end] in "eE":
+    while end < len(l) and l[end] in "1234567890.eEdD-+":
+        if l[end] in "eEdD":
             if eSeen:
                 break
             eSeen = True
@@ -28,47 +29,88 @@ def _getNumberAt(l, pos):
         end += 1
     return l[start:end], l[end:]
 
+
 def _fpequalAtPos(l1, l2, tolerance, relTolerance, pos):
     number1, l1 = _getNumberAt(l1, pos)
     number2, l2 = _getNumberAt(l2, pos)
+
+    equal = _fpTestForTolerance(number1, number2, tolerance, relTolerance)
+
+    return equal, l1, l2
+
+
+def _fpTestForTolerance(w1, w2, tolerance, relTolerance):
     try:
         equal = False
-        deviation = abs(float(number1) - float(number2))
+        w1 = w1.replace("d","e",1)
+        w1 = w1.replace("D","e",1)
+        w2 = w2.replace("d","e",1)
+        w2 = w2.replace("D","e",1)
+        deviation = abs(float(w1) - float(w2))
         if tolerance != None and deviation <= tolerance:
             equal = True
         elif relTolerance != None:
-            referenceValue = abs(float(number1))
+            referenceValue = abs(float(w1))
             if referenceValue == 0:
                 equal = (deviation == 0)
             elif deviation / referenceValue <= relTolerance:
                 equal = True
     except ValueError:
         pass
-    return equal, l1, l2
+    return equal
 
-def _fpequal(l1, l2, tolerance, relTolerance):
-    pos = 0
-    while pos < min(len(l1), len(l2)):
-        if l1[pos] != l2[pos]:
-            equal, l1, l2 = _fpequalAtPos(l1, l2, tolerance, relTolerance, pos)
-            if not equal:
-                return False
-            pos = 0
+
+def _fpequal(l1, l2, tolerance, relTolerance, model=0):
+    if model == 0:
+        pos = 0
+        while pos < min(len(l1), len(l2)):
+            if l1[pos] != l2[pos]:
+                equal, l1, l2 = _fpequalAtPos(l1, l2, tolerance, relTolerance, pos)
+                if not equal:
+                    return False
+                pos = 0
+            else:
+                pos += 1
+        if len(l1) == len(l2):
+            return True
         else:
-            pos += 1
-    if len(l1) == len(l2):
-        return True
-    else:
-        return _fpequalAtPos(l1, l2, tolerance, relTolerance, pos)[0]
+            return _fpequalAtPos(l1, l2, tolerance, relTolerance, pos)[0]
+    elif model == 1:
+        regNumber = r'[-+]? (?: (?: \d* \. \d+ ) | (?: \d+ \.? ) )(?: [EeDd] [+-]? \d+ ) ?'
+        numbers1 = re.findall(regNumber, l1, re.VERBOSE)
+        numbers2 = re.findall(regNumber, l2, re.VERBOSE)
+        isEqual = True
+        if len(numbers1) != len(numbers2):
+            isEqual = False
+        else:
+            for n1, n2 in zip(numbers1, numbers2):
+                isEqual = _fpTestForTolerance(n1, n2, tolerance, relTolerance)
+                if not isEqual:
+                    break
 
-def fpfilter(fromlines, tolines, outlines, tolerance, relTolerance=None):
-    s = difflib.SequenceMatcher(None, fromlines, tolines)
-    for tag, i1, i2, j1, j2 in s.get_opcodes():
-        if tag == "replace" and i2 - i1 == j2 - j1:
-            for fromline, toline in zip(fromlines[i1:i2], tolines[j1:j2]):
-                if _fpequal(fromline, toline, tolerance, relTolerance):
+        return isEqual
+
+
+def fpfilter(fromlines, tolines, outlines, tolerance, relTolerance=None, model=0):
+    if model == 0:
+        s = difflib.SequenceMatcher(None, fromlines, tolines)
+        for tag, i1, i2, j1, j2 in s.get_opcodes():
+
+            if tag == "replace" and i2 - i1 == j2 - j1:
+                for fromline, toline in zip(fromlines[i1:i2], tolines[j1:j2]):
+                    if _fpequal(fromline, toline, tolerance, relTolerance, model=0):
+                        outlines.write(fromline)
+                    else:
+                        outlines.write(toline)
+            else:
+                outlines.writelines(tolines[j1:j2])
+    elif model == 1:
+        if len(fromlines) == len(tolines):
+            for fromline, toline in zip(fromlines, tolines):
+                if _fpequal(fromline, toline, tolerance, relTolerance, model=1):
                     outlines.write(fromline)
                 else:
                     outlines.write(toline)
         else:
-            outlines.writelines(tolines[j1:j2])
+            outlines.writelines(tolines)
+


### PR DESCRIPTION
The following changes have been implemented:

- Fortran uses the following format for Double Precision float numbers in scientific notification: 1.234D+1. These numbers haven't been recognized by the original float diff model (implemented by Michael Behrisch). They do now. Once recognized as numbers the 'dD' has to be converted back to an 'e' to avoid issues with Python's float() method.
- A 2nd model to compare floats has been implemented. I was running in some of my test cases into an issue which is not directly related to Michael's float diff engine but is due to the difflib.SequenceMatcher it is using. Therefore I have implemented a 2nd model for float diff which is working fine now for all of my test cases. 

It can be configured via the config file via entry 'float_diff_model'. Michael's model is still the default model for backward compability.

The example below will use Michael's model for file1 and the new model for file2. If the block is not present in the config file, Michael's model will be used if 'floating_point_tolerance' or 'relative_float_tolerance' have been defined.

[float_diff_model]
file1: 0
file2: 1
[end]

Any comments?