### PR TITLE
More compact host format, less precision for progress

### DIFF
--- a/texttestlib/default/batch/testoverview.py
+++ b/texttestlib/default/batch/testoverview.py
@@ -32,16 +32,6 @@ def parseState(state):
         return "", hosts
 
 
-def compactHostRepr(hosts):
-    """Convert list ['a', 'a', 'b'] -> 'a*2, b'"""
-    hostCount = dict((host, hosts.count(host)) for host in set(hosts))
-    hostCountStrings = \
-        (('*'.join([host, str(hostCount[host])])
-          if hostCount[host] > 1 else host
-          for host in hostCount))
-    return ', '.join(hostCountStrings)
-
-
 def getWeekDay(tag):
     return plugins.weekdays[time.strptime(tag.split("_")[0], "%d%b%Y")[6]]
 
@@ -689,7 +679,7 @@ class TestTable:
         fgcol, bgcol = self.getColours(category, fileComp)
         if not hasattr(state, "category"):
             brief, hosts = parseState(state)
-            return "ok " + brief + compactHostRepr(hosts), True, fgcol, bgcol
+            return "ok " + brief + plugins.compactHostRepr(hosts), True, fgcol, bgcol
         success = category == "success"
         if success:
             cellContent = "ok"
@@ -697,7 +687,7 @@ class TestTable:
                 cellContent += " " + state.briefText
         else:
             cellContent = state.getTypeBreakdown()[1]
-        cellContent += " " + compactHostRepr(state.executionHosts)
+        cellContent += " " + plugins.compactHostRepr(state.executionHosts)
         return cellContent.strip(), success, fgcol, bgcol
 
     def getCellDataFromFileComp(self, fileComp):

--- a/texttestlib/default/comparetest.py
+++ b/texttestlib/default/comparetest.py
@@ -506,7 +506,9 @@ class ProgressTestComparison(BaseTestComparison):
     def progressText(self):
         perc = self.calculatePercentage()
         if perc is not None:
-            return "\nReckoned to be " + str(perc) + "% complete by comparing total file sizes at " + plugins.localtime() + "."
+            return "\nReckoned to be " + str(int(perc)) \
+                + "% complete by comparing total file sizes at " \
+                + plugins.localtime() + "."
         else:
             return ""
 

--- a/texttestlib/default/runtest.py
+++ b/texttestlib/default/runtest.py
@@ -59,9 +59,12 @@ class RunTest(plugins.Action):
 
     def changeToRunningState(self, test):
         execMachines = test.state.executionHosts
-        self.diag.info("Changing " + repr(test) + " to state Running on " + repr(execMachines))
+        self.diag.info("Changing {} to state Running on {}".format(
+            repr(test),
+            repr(execMachines)))
+
         briefText = self.getBriefText(execMachines)
-        freeText = "Running on " + ",".join(execMachines)
+        freeText = "Running on {}".format(plugins.compactHostRepr(execMachines))
         newState = Running(execMachines, briefText=briefText, freeText=freeText)
         test.changeState(newState)
 

--- a/texttestlib/plugins.py
+++ b/texttestlib/plugins.py
@@ -58,6 +58,16 @@ def findInstallationRoots():
     return roots
 
 
+def compactHostRepr(hosts):
+    """Convert list ['a', 'a', 'b'] -> 'a*2, b'"""
+    hostCount = dict((host, hosts.count(host)) for host in set(hosts))
+    hostCountStrings = \
+        (('*'.join([str(hostCount[host]), host])
+          if hostCount[host] > 1 else host
+          for host in hostCount))
+    return ', '.join(sorted(hostCountStrings))
+
+
 globalStartTime = datetime.now()
 datetimeFormat = "%d%b%H:%M:%S"
 installationRoots = findInstallationRoots()
@@ -738,7 +748,7 @@ class TestState(Observable):
         return longDescription
 
     def hostString(self):
-        return "on " + ", ".join(self.executionHosts)
+        return "on " + compactHostRepr(self.executionHosts)
 
     def hostRepr(self):
         if self.showExecHosts and len(self.executionHosts) > 0:

--- a/texttestlib/queuesystem/slavejobs.py
+++ b/texttestlib/queuesystem/slavejobs.py
@@ -27,7 +27,7 @@ def importAndCallFromQueueSystem(app, *args):
 # Use a non-monitoring runTest, but the rest from unix
 class RunTestInSlave(RunTest):
     def getBriefText(self, execMachines):
-        return "RUN (" + ",".join(execMachines) + ")"
+        return "RUN ({})".format(plugins.compactHostRepr(execMachines))
 
     def getKillInfoOtherSignal(self, test):
         if os.name == "posix":


### PR DESCRIPTION
Nowadays it is more common to run on multiple threads than on different hosts. The old format became very repetitive, especially running on 32 cores. This merge re-uses the format from the web pages, with slight modifications.

Also changed so progress is displayed as integer percentage, instead of excessive precision.

There were a few test changes, they are in the corresponding branch on the test repo: https://github.com/texttest/selftest/tree/host-format