### PR TITLE
Check if default gtk settings are None

### DIFF
--- a/texttestlib/default/gtkgui/guiutils.py
+++ b/texttestlib/default/gtkgui/guiutils.py
@@ -315,10 +315,11 @@ class GUIConfig:
     @staticmethod
     def isDarkTheme():
         settings = Gtk.Settings.get_default()
-        if settings.get_property("gtk-application-prefer-dark-theme"):
-            return True
-        if "dark" in settings.get_property("gtk-theme-name"):
-            return True
+        if settings:
+            if settings.get_property("gtk-application-prefer-dark-theme"):
+                return True
+            if "dark" in settings.get_property("gtk-theme-name"):
+                return True
         return "dark" in os.getenv("GTK_THEME", "")
 
     @staticmethod


### PR DESCRIPTION
We got `None `from the call to `Gtk.Settings.get_default()`. Don't know why really, but added a guard.