### PR TITLE
Extend filter functionality for HTML reports

### DIFF
--- a/texttestlib/default/batch/testoverview.py
+++ b/texttestlib/default/batch/testoverview.py
@@ -641,9 +641,7 @@ class TestTable:
             cellContent, bgcol, hasData = self.generateTestCell(tag, testName, testId, results)
             testRow.append(HTMLgen.TD(cellContent, bgcolor=bgcol))
             foundData |= hasData
-            if hasData:
-                # Keep track of colour for filtering purposes
-                self.usedColours.add(bgcol)
+            self.usedColours.add(bgcol)
 
         if foundData:
             rows.append(HTMLgen.TR(*testRow))

--- a/texttestlib/default/batch/testoverview.py
+++ b/texttestlib/default/batch/testoverview.py
@@ -209,7 +209,7 @@ class GenerateWebPages(object):
                         page, pageColours = self.pagesOverview[filePath]
                     else:
                         page = self.createPage()
-                        pageColours = set()
+                        pageColours = {"last_column": set(), "all_columns": set()}
                         self.pagesOverview[filePath] = page, pageColours
 
                     tableHeader = self.getTableHeader(version, repositoryDirs)
@@ -217,7 +217,8 @@ class GenerateWebPages(object):
                     hasNewData, graphLink, tableColours = self.addTable(page, self.resourceNames, categoryHandlers, version,
                                                                         loggedTests, sel, tableHeader, filePath, heading, repositoryDirInfo)
                     hasData |= hasNewData
-                    pageColours.update(tableColours)
+                    for colourGroupKey in tableColours:
+                        pageColours[colourGroupKey].update(tableColours[colourGroupKey])
                     if graphLink:
                         pageToGraphs.setdefault(page, []).append(graphLink)
 
@@ -259,7 +260,7 @@ class GenerateWebPages(object):
             creationDate = TitleWithDateStamp("").__str__().strip()
             page.prepend(HTMLgen.Paragraph(creationDate, align="center"))
             page.prepend(HTMLgen.Heading(1, self.getHeading(), align='center'))
-            if len(pageColours) > 0:
+            if any((len(pageColoursGroup) > 0 for pageColoursGroup in pageColours.values())):
                 page.prepend(HTMLgen.BR())
                 page.prepend(HTMLgen.BR())
                 page.script = self.getFilterScripts(pageColours)
@@ -271,9 +272,13 @@ class GenerateWebPages(object):
         rowHeaderColour = finder.find("row_header_bg")
         successColour = finder.find("success_bg")
         # Always put green at the start, we often want to filter that
-        sortedColours = sorted(pageColours, key=lambda c: (c != successColour, c))
+        lastColumnColours = pageColours.get("last_column", set())
+        allColumnsColours = pageColours.get("all_columns", set())
+        sortedColours = sorted(lastColumnColours, key=lambda c: (c != successColour, c))
+        sortedColoursAll = sorted(allColumnsColours, key=lambda c: (c != successColour, c not in sortedColours, c))
         scriptCode = "var TEST_ROW_HEADER_COLOR = " + repr(rowHeaderColour) + ";\n" + \
-                     "var Colors = " + repr(sortedColours) + ";"
+                     "var Colors = " + repr(sortedColoursAll) + ";\n" + \
+                     "var ColorsLastCol = " + repr(sortedColours) + ";"
         scripts = [HTMLgen.Script(code=scriptCode),
                    HTMLgen.Script(src="../javascript/jquery.js"),
                    HTMLgen.Script(src="../javascript/filter.js")]
@@ -474,7 +479,7 @@ class TestTable:
         self.pageVersion = pageVersion
         self.version = version
         self.graphFilePath = graphFilePath  # For convenience in performance analyzer.
-        self.usedColours = set()
+        self.usedColours = {"last_column": set(), "all_columns": set()}
 
     def generateGraph(self, fileName, heading):
         if len(self.tags) > 1:  # Don't bother with graphs when tests have only run once
@@ -641,9 +646,10 @@ class TestTable:
             cellContent, bgcol, hasData = self.generateTestCell(tag, testName, testId, results)
             testRow.append(HTMLgen.TD(cellContent, bgcolor=bgcol))
             foundData |= hasData
-            self.usedColours.add(bgcol)
+            self.usedColours["all_columns"].add(bgcol)
 
         if foundData:
+            self.usedColours["last_column"].add(bgcol)
             rows.append(HTMLgen.TR(*testRow))
         else:
             return rows

--- a/texttestlib/default/batch/testoverview.py
+++ b/texttestlib/default/batch/testoverview.py
@@ -641,10 +641,11 @@ class TestTable:
             cellContent, bgcol, hasData = self.generateTestCell(tag, testName, testId, results)
             testRow.append(HTMLgen.TD(cellContent, bgcolor=bgcol))
             foundData |= hasData
+            if hasData:
+                # Keep track of colour for filtering purposes
+                self.usedColours.add(bgcol)
 
         if foundData:
-            # We only filter based on the final column
-            self.usedColours.add(bgcol)
             rows.append(HTMLgen.TR(*testRow))
         else:
             return rows

--- a/texttestlib/default/batch/testoverview_javascript/filter.js
+++ b/texttestlib/default/batch/testoverview_javascript/filter.js
@@ -124,6 +124,15 @@ Filter.prototype.apply = function()
 Filter.prototype.setFilterStrategy = function(filterStrategy)
 {
     this.filterStrategy = filterStrategy;
+    // Older reports will not have ColorsLastCol defined and hence
+    // will show all filter buttons as options
+    if (window.ColorsLastCol !== undefined)
+    {
+        $(".colortoggle").each((i, element) => {
+            const visible = (filterStrategy !== STRATEGY_LAST_TEST || ColorsLastCol.includes(element.dataset.color));
+            $(element.parentNode).toggle(visible);
+        });
+    }
     this.apply();
 };
 
@@ -173,7 +182,7 @@ var createFilterStrategySelector = function(filter) {
 // Create html and behavior of a category toggler
 var createCategoryToggler = function(filter, category, id)
 {
-    var toggler = $('<div title="Toggle this category" id=color' + id + '></div>');
+    var toggler = $('<div title="Toggle this category" class=colortoggle id=color' + id + ' data-color="' + category.color + '"></div>');
     toggler.css({
             'position' : 'relative',
 	    'background-color': category.color,
@@ -270,6 +279,7 @@ var init = function()
     toolbarContent.append(layoutTable);
     $(document.body).append(toolbarContent);
 
+    filter.setFilterStrategy(STRATEGY_LAST_TEST);
     filter.apply();
 };
 

--- a/texttestlib/default/batch/testoverview_javascript/filter.js
+++ b/texttestlib/default/batch/testoverview_javascript/filter.js
@@ -1,4 +1,8 @@
 
+// Enum values for strategy choice
+var STRATEGY_LAST_TEST = 'LAST';
+var STRATEGY_ANY_TESTS = 'ANY';
+
 // A test result category.
 // - Containts its color and view state
 var Category = function(color)
@@ -18,6 +22,8 @@ var TestRow = function(trElem)
 {
     var tdList = trElem.getElementsByTagName('td');
     this.lastCol = tdList[tdList.length-1];
+    const [, ...dataCells] = tdList;
+    this.allCols = dataCells;
     this.row = trElem;
     this.testName = $(tdList[0]).text().replace(/\n/g,"");
 };
@@ -43,20 +49,32 @@ var Filter = function(bodyElem)
         this.categories.push(new Category(Colors[i]));
 
     this.numTestsVisible = -1;   // initiated on apply()
+    this.filterStrategy = STRATEGY_LAST_TEST;
     this.textFilter = null;      
     this.onUpdateCallbacks = []; 
+};
+
+// Check if row matches filter for specific category
+Filter.prototype.matchesCategoryFilter = function(cat, testRow)
+{
+    if (this.filterStrategy === STRATEGY_LAST_TEST)
+        return cat.appliesTo(testRow.lastCol);
+    else if (this.filterStrategy === STRATEGY_ANY_TESTS)
+        return testRow.allCols.some((col) => cat.appliesTo(col));
+    console.log('Unknown filter strategy');
+    return true;
 };
 
 // Hide/Show a single row
 Filter.prototype.setRowVisibility = function(testRow, textFilterRegExp)
 {
-    var visible = true;
+    var visible = false;
     for (var i = 0; i < this.categories.length; ++i)
     {
 	var cat = this.categories[i];
-	if (cat.appliesTo(testRow.lastCol))
+	if (cat.isVisible && this.matchesCategoryFilter(cat, testRow))
 	{
-	    visible = cat.isVisible;
+	    visible = true;
 	    break;
 	}
     }
@@ -103,6 +121,12 @@ Filter.prototype.apply = function()
     this.fireOnUpdate();
 };
 
+Filter.prototype.setFilterStrategy = function(filterStrategy)
+{
+    this.filterStrategy = filterStrategy;
+    this.apply();
+};
+
 Filter.prototype.showOnly = function(category)
 {
     for (var i = 0; i < this.categories.length; ++i)
@@ -127,6 +151,23 @@ Filter.prototype.reset = function()
         this.categories[i].isVisible = true;
     }
     this.apply();
+};
+
+// Create html and behavior to choose filter strategy
+var createFilterStrategySelector = function(filter) {
+    var selector = $('<select title=\'Select filter strategy\'></select>');
+    selector.css({
+        'padding': '0px 10px',
+        'height': '100%'
+    });
+    selector.append($(`<option value=${STRATEGY_LAST_TEST} title="Show row if last run matches any active filter">Last run</option>`));
+    selector.append($(`<option value=${STRATEGY_ANY_TESTS} title="Show row if any run matches any active filter">Any run</option>`));
+    selector.change(function()
+    {
+        const strategy = $(this).find(":selected").val();
+        filter.setFilterStrategy(strategy);
+    });
+    return selector;
 };
 
 // Create html and behavior of a category toggler
@@ -188,6 +229,10 @@ var init = function()
 		
     // The filter instance
     var filter = new Filter(document.body);
+
+    var levelTd = $('<td height=30></td>');
+    levelTd.append(createFilterStrategySelector(filter));
+    layoutRow.append(levelTd);
 
     // Populate toolbar with category togglers
     for (var i = 0; i < filter.categories.length; ++i)


### PR DESCRIPTION
The filter section at the top of HTML reports now include an option to either filter on the most previous run (current way) or any run visible in the table. This addition would make it easier to filter for sporadic errors.