### PR TITLE
Fix display settings before constructing submit cmd args

### DIFF
--- a/texttestlib/queuesystem/abstractqueuesystem.py
+++ b/texttestlib/queuesystem/abstractqueuesystem.py
@@ -10,6 +10,9 @@ class QueueSystem(object):
     def __init__(self, *args):
         pass
 
+    def prepareEnvForSubmit(self, slaveEnv):
+        pass
+
     def submitSlaveJob(self, cmdArgs, slaveEnv, logDir, submissionRules, jobType):
         try:
             process = subprocess.Popen(cmdArgs, stdout=subprocess.PIPE, stderr=subprocess.PIPE,

--- a/texttestlib/queuesystem/gridqueuesystem.py
+++ b/texttestlib/queuesystem/gridqueuesystem.py
@@ -16,8 +16,10 @@ class QueueSystem(abstractqueuesystem.QueueSystem):
         if display and display.startswith(":"):
             env["DISPLAY"] = plugins.gethostname() + display
 
-    def submitSlaveJob(self, cmdArgs, slaveEnv, logDir, *args, **kw):
+    def prepareEnvForSubmit(self, slaveEnv):
         self.fixDisplay(slaveEnv)
+
+    def submitSlaveJob(self, cmdArgs, slaveEnv, logDir, *args, **kw):
         # Don't use log dir as working directory, it might not exist yet
         return abstractqueuesystem.QueueSystem.submitSlaveJob(self, cmdArgs, slaveEnv, self.coreFileLocation, *args, **kw)
 

--- a/texttestlib/queuesystem/masterprocess.py
+++ b/texttestlib/queuesystem/masterprocess.py
@@ -523,6 +523,8 @@ class QueueSystemServer(BaseActionRunner):
         self.diag.info("Creating job at " + plugins.localtime())
         self.fixConfigEnv(slaveEnv, test)
         self.fixProxyVar(slaveEnv, test, withProxy)
+        queueSystem = self.getQueueSystem(test)
+        queueSystem.prepareEnvForSubmit(slaveEnv)
         cmdArgs = self.getSubmitCmdArgs(test, submissionRules, commandArgs, slaveEnv)
         if withProxy:
             cmdArgs = self.modifyCommandForProxy(test, cmdArgs, slaveEnv)
@@ -536,7 +538,6 @@ class QueueSystemServer(BaseActionRunner):
                 return False
 
             self.lockDiag.info("Got lock for submission")
-            queueSystem = self.getQueueSystem(test)
             logDir = self.getSlaveLogDir(test)
             jobId, errorMessage = queueSystem.submitSlaveJob(cmdArgs, slaveEnv, logDir, submissionRules, jobType)
             if jobId is not None:


### PR DESCRIPTION
This fixes a bug introduced in 636e490fb34e45b603c3af88129f2209cae11b55. We need to call the `fixDisplay` function before fetching the submit command args to properly determine whether to use the `-v DISPLAY` flag to SGE.

I wasn't sure whether this solution or a smaller solution for only gridqueuesystem was the best approach, but this allows for more adjustments for any queue system in the future if needed without touching the master process code.