### PR TITLE
Treat localhost:0 and :0 identically

### DIFF
--- a/texttestlib/queuesystem/gridqueuesystem.py
+++ b/texttestlib/queuesystem/gridqueuesystem.py
@@ -13,8 +13,8 @@ class QueueSystem(abstractqueuesystem.QueueSystem):
     def fixDisplay(self, env):
         # Must make sure SGE jobs don't get a locally referencing DISPLAY
         display = os.environ.get("DISPLAY")
-        if display and display.startswith(":"):
-            env["DISPLAY"] = plugins.gethostname() + display
+        if display and (display.startswith(":") or display.startswith("localhost:")):
+            env["DISPLAY"] = plugins.gethostname() + ":" + display.split(":", 1)[1]
 
     def prepareEnvForSubmit(self, slaveEnv):
         self.fixDisplay(slaveEnv)


### PR DESCRIPTION
We need to consider the case where the host explicitly specifies `localhost` as the host in the `DISPLAY` variable. E.g. `localhost:0` should be treated the same as `:0`.

This will also (correctly) affect some selftests. See separate MR in https://github.com/texttest/selftest/pull/9