### PR TITLE
Add support for Gitlab CI

### DIFF
--- a/texttestlib/default/batch/__init__.py
+++ b/texttestlib/default/batch/__init__.py
@@ -12,6 +12,7 @@ import stat
 from texttestlib.default.batch import testoverview
 from texttestlib import plugins
 from .summarypages import GenerateSummaryPage, GenerateGraphs  # only so they become package level entities
+from .ci import CIPlatform
 from collections import OrderedDict
 from .batchutils import getBatchRunName, BatchVersionFilter, parseFileName, convertToUrl
 import subprocess
@@ -561,10 +562,8 @@ class SaveState(plugins.Responder):
     def makeInitialRunFile(self, app, runFile):
         plugins.ensureDirExistsForFile(runFile)
         with open(runFile, "w") as f:
-            jenkinsVars = ["JENKINS_URL", "JOB_NAME", "BUILD_NUMBER"]
-            if not self.addVarsToRunFile(f, jenkinsVars):
-                azdoVars = ["SYSTEM_TEAMFOUNDATIONSERVERURI", "SYSTEM_TEAMPROJECT", "BUILD_BUILDID", "BUILD_BUILDNUMBER" ]
-                self.addVarsToRunFile(f, azdoVars)
+            runFileVars = CIPlatform.getInstance().getRunFileVars()
+            self.addVarsToRunFile(f, runFileVars)
             f.write(repr(app) + "\n")
 
     def runAlreadyExists(self, runFile, app):

--- a/texttestlib/default/batch/batchutils.py
+++ b/texttestlib/default/batch/batchutils.py
@@ -2,6 +2,7 @@ import datetime
 import time
 import os
 from texttestlib import plugins
+from .ci import CIPlatform
 
 
 class BatchVersionFilter:
@@ -29,13 +30,10 @@ def getBatchRunName(optionMap):
     if name is not None:
         return name
 
-    if "BUILD_BUILDNUMBER" in os.environ:
-        ciBuildNumber = os.getenv("BUILD_BUILDNUMBER").split(".")[-1] # Azure Devops, which includes the date
-    else:
-        ciBuildNumber = os.getenv("BUILD_NUMBER") # Jenkins, which does not include the date
+    ciBuildNumber = CIPlatform.getInstance().getBuildNumber()
     timeToUse = plugins.globalStartTime
     if ciBuildNumber is None:
-        # If we're not using Jenkins, assume some kind of nightjob set up (mostly for historical reasons)
+        # If we're not using a CI system, assume some kind of nightjob set up (mostly for historical reasons)
         # Here we use a standardised date that give a consistent answer for night-jobs.
         # Hence midnight is a bad cutover point. The day therefore starts and ends at 8am :)
         timeToUse -= datetime.timedelta(hours=8)

--- a/texttestlib/default/batch/ci.py
+++ b/texttestlib/default/batch/ci.py
@@ -1,0 +1,193 @@
+import os
+import urllib.parse
+from texttestlib.default.batch import jenkinschanges
+from pprint import pformat
+from texttestlib import plugins
+
+class CIPlatform:
+
+    @staticmethod
+    def getInstance(environment=os.environ):
+        if environment.get("JENKINS_URL"):
+            platform = Jenkins(environment)
+        elif environment.get("SYSTEM_TEAMFOUNDATIONSERVERURI"):
+            platform = Azure(environment)
+        elif environment.get("GITLAB_CI"):
+            platform = Gitlab(environment)
+        else:
+            platform = CIPlatform(environment)
+        return platform
+
+    def __init__(self, environment):
+        self.environment = environment
+        self.currentTag = None
+
+    def _getEnvProperty(self, prop, defaultVal=""):
+        return self.environment.get(prop, defaultVal) if self.environment else defaultVal
+
+    """
+    Some old Jenkins instances don't always have a build number set as
+    and environment variable. This is a way to support backwards compat
+    with those jobs, since build number can be fetched from tag name
+    """
+    def setCurrentTag(self, tag):
+        self.currentTag = tag
+
+    def name(self):
+        return "Generic platform"
+
+    def hasFullEnvironment(self):
+        return not any((self._getEnvProperty(var, None) is None for var in self.getRunFileVars()))
+
+    def supportsEnvironmentComparison(self):
+        return False
+
+    def getRunFileVars(self):
+        return []
+
+    def getBuildNumber(self):
+        return None
+
+    def getCiUrl(self):
+        return None
+
+    def getJobName(self):
+        return None
+
+    def getJobUrl(self):
+        return None
+
+    def getJobTitle(self):
+        return None
+
+    def getJobTooltip(self):
+        return ""
+
+    def getPrettyJobLink(self):
+        return None
+
+    def getBuildNumberFromTag(self, tag):
+        return tag.split(".")[-1]
+
+    def findChanges(self, prevTag, tag, pageDir, getConfigValue):
+        return []
+
+
+class Jenkins(CIPlatform):
+
+    def name(self):
+        return "Jenkins"
+
+    def supportsEnvironmentComparison(self):
+        return True
+
+    def getRunFileVars(self):
+        return ["JENKINS_URL", "JOB_NAME", "BUILD_NUMBER"]
+
+    def getBuildNumber(self):
+        if self.currentTag:
+            return self.getBuildNumberFromTag(self.currentTag)
+        return self._getEnvProperty("BUILD_NUMBER")
+
+    def getCiUrl(self):
+        return self._getEnvProperty("JENKINS_URL")
+
+    def getJobName(self):
+        return self._getEnvProperty("JOB_NAME")
+
+    def getJobUrl(self):
+        return os.path.join(self.getCiUrl(), "job", self.getJobName(), self.getBuildNumber())
+
+    def getJobTitle(self):
+        return "Jenkins " + self.getBuildNumber()
+
+    def getJobTooltip(self):
+        return jenkinschanges.getTimestamp(self.getBuildNumber())
+
+    def getPrettyJobLink(self):
+        return f"(built by Jenkins job '{self.getJobName()}', <a href='{self.getJobUrl()}'> build number {self.getBuildNumber()}</a>)"
+
+    def findChanges(self, prevTag, tag, pageDir, getConfigValue):
+        cacheDir = os.path.join(os.path.dirname(pageDir), "jenkins_changes")
+        buildNumber = self.getBuildNumberFromTag(tag)
+        cacheFileOldName = os.path.join(cacheDir, buildNumber)
+        cacheFile = os.path.join(cacheDir, tag)
+        if os.path.isfile(cacheFileOldName):
+            os.rename(cacheFileOldName, cacheFile)
+        if os.path.isfile(cacheFile):
+            return eval(open(cacheFile).read().strip())
+        else:
+            bugSystemData = getConfigValue("bug_system_location", allSubKeys=True)
+            markedArtefacts = getConfigValue("batch_jenkins_marked_artefacts")
+            fileFinder = getConfigValue("batch_jenkins_archive_file_pattern")
+            prevBuildNumber = self.getBuildNumberFromTag(prevTag) if prevTag else None
+            if buildNumber.isdigit() and prevBuildNumber is not None:
+                try:
+                    allChanges = jenkinschanges.getChanges(
+                        prevBuildNumber, buildNumber, bugSystemData, markedArtefacts, fileFinder, cacheDir)
+                    plugins.ensureDirectoryExists(cacheDir)
+                    with open(cacheFile, "w") as f:
+                        f.write(pformat(allChanges) + "\n")
+                    return allChanges
+                except jenkinschanges.JobStillRunningException:
+                    pass  # don't write to cache in this case
+            return []
+
+
+class Azure(CIPlatform):
+
+    def name(self):
+        return "Azure Devops"
+
+    def getRunFileVars(self):
+        return ["SYSTEM_TEAMFOUNDATIONSERVERURI", "SYSTEM_TEAMPROJECT", "BUILD_BUILDID", "BUILD_BUILDNUMBER"]
+
+    def getBuildNumber(self):
+        if self.currentTag:
+            return self.getBuildNumberFromTag(self.currentTag)
+        return self._getEnvProperty("BUILD_BUILDNUMBER").split(".")[-1]
+
+    def getCiUrl(self):
+        return self._getEnvProperty("SYSTEM_TEAMFOUNDATIONSERVERURI")
+
+    def getJobName(self):
+        return self._getEnvProperty("SYSTEM_DEFINITIONNAME")
+
+    def getJobUrl(self):
+        project = urllib.parse.quote(self._getEnvProperty("SYSTEM_TEAMPROJECT"))
+        return os.path.join(self.getCiUrl(), project, "_build", "results?buildId=" + self._getEnvProperty("BUILD_BUILDID"))
+
+    def getJobTitle(self):
+        return "AZ DevOps " + self._getEnvProperty("BUILD_BUILDNUMBER")
+
+    def getPrettyJobLink(self):
+        builtBy = "Azure Devops Pipeline"
+        fullBuildNo = self._getEnvProperty("BUILD_BUILDNUMBER")
+        return f"(built by {builtBy} '{self.getJobName()}', <a href='{self.getJobUrl()}'> build number {fullBuildNo}</a>)"
+
+
+class Gitlab(CIPlatform):
+
+    def name(self):
+        return "Gitlab CI"
+
+    def getRunFileVars(self):
+        return ["GITLAB_CI", "CI_JOB_ID", "CI_SERVER_URL", "CI_JOB_NAME", "CI_JOB_URL"]
+
+    def getBuildNumber(self):
+        return self._getEnvProperty("CI_JOB_ID")
+
+    def getCiUrl(self):
+        return self._getEnvProperty("CI_SERVER_URL")
+
+    def getJobName(self):
+        return self._getEnvProperty("CI_JOB_NAME")
+
+    def getJobUrl(self):
+        return self._getEnvProperty("CI_JOB_URL")
+
+    def getJobTitle(self):
+        return "Gitlab Pipeline #" + self.getBuildNumber()
+
+    def getPrettyJobLink(self):
+        return f"(built by Gitlab Pipeline '{self.getJobName()}', <a href='{self.getJobUrl()}'> job #{self.getBuildNumber()}</a>)"

--- a/texttestlib/default/batch/ci.py
+++ b/texttestlib/default/batch/ci.py
@@ -27,7 +27,7 @@ class CIPlatform:
 
     """
     Some old Jenkins instances don't always have a build number set as
-    and environment variable. This is a way to support backwards compat
+    an environment variable. This is a way to support backwards compat
     with those jobs, since build number can be fetched from tag name
     """
     def setCurrentTag(self, tag):

--- a/texttestlib/default/batch/testoverview.py
+++ b/texttestlib/default/batch/testoverview.py
@@ -8,12 +8,12 @@ import sys
 import logging
 import locale
 from texttestlib.default.batch import HTMLgen, HTMLcolors
+from texttestlib.default.batch.ci import CIPlatform
 from texttestlib import plugins
 from collections import OrderedDict
 from glob import glob
 from datetime import datetime, timedelta
 from .batchutils import convertToUrl, getEnvironmentFromRunFiles
-from .ci import CIPlatform
 HTMLgen.PRINTECHO = 0
 
 
@@ -739,9 +739,9 @@ class TestTable:
         return runNameDirs
 
     def getCIPlatformForTableHead(self, runNameDirs, tag):
+        runEnv = getEnvironmentFromRunFiles(runNameDirs, tag)
         platformEnv = {}
         platformEnv.update(os.environ)
-        runEnv = getEnvironmentFromRunFiles(runNameDirs, tag)
         platformEnv.update(runEnv)
         ciPlatform = CIPlatform.getInstance(platformEnv)
         ciPlatform.setCurrentTag(tag)

--- a/texttestlib/default/batch/testoverview.py
+++ b/texttestlib/default/batch/testoverview.py
@@ -7,14 +7,13 @@ import html
 import sys
 import logging
 import locale
-from texttestlib.default.batch import HTMLgen, HTMLcolors, jenkinschanges
+from texttestlib.default.batch import HTMLgen, HTMLcolors
 from texttestlib import plugins
 from collections import OrderedDict
 from glob import glob
-from pprint import pformat
 from datetime import datetime, timedelta
 from .batchutils import convertToUrl, getEnvironmentFromRunFiles
-import urllib.parse
+from .ci import CIPlatform
 HTMLgen.PRINTECHO = 0
 
 
@@ -500,10 +499,9 @@ class TestTable:
         table = HTMLgen.TableLite(border=0, cellpadding=4, cellspacing=2, width="100%")
         table.append(self.generateTableHead(repositoryDirs))
         table.append(self.generateSummaries())
-        if os.getenv("JENKINS_URL"):
-            changeRow = self.generateJenkinsChanges(pageDir)
-            if changeRow:
-                table.append(changeRow)
+        changeRow = self.generateCIChanges(pageDir)
+        if changeRow:
+            table.append(changeRow)
         hasRows = False
         for extraVersion, testInfo in list(loggedTests.items()):
             currRows = []
@@ -533,42 +531,17 @@ class TestTable:
             table.append(HTMLgen.BR())
             return table
 
-    def findJenkinsChanges(self, prevTag, tag, cacheDir):
-        buildNumber = self.getCiBuildNumber(tag)
-        cacheFileOldName = os.path.join(cacheDir, buildNumber)
-        cacheFile = os.path.join(cacheDir, tag)
-        if os.path.isfile(cacheFileOldName):
-            os.rename(cacheFileOldName, cacheFile)
-        if os.path.isfile(cacheFile):
-            return eval(open(cacheFile).read().strip())
-        else:
-            bugSystemData = self.getConfigValue("bug_system_location", allSubKeys=True)
-            markedArtefacts = self.getConfigValue("batch_jenkins_marked_artefacts")
-            fileFinder = self.getConfigValue("batch_jenkins_archive_file_pattern")
-            prevBuildNumber = self.getCiBuildNumber(prevTag) if prevTag else None
-            if buildNumber.isdigit() and prevBuildNumber is not None:
-                try:
-                    allChanges = jenkinschanges.getChanges(
-                        prevBuildNumber, buildNumber, bugSystemData, markedArtefacts, fileFinder, cacheDir)
-                    plugins.ensureDirectoryExists(cacheDir)
-                    with open(cacheFile, "w") as f:
-                        f.write(pformat(allChanges) + "\n")
-                    return allChanges
-                except jenkinschanges.JobStillRunningException:
-                    pass  # don't write to cache in this case
-            return []
+    def generateCIChanges(self, pageDir):
+        ciPlatform = CIPlatform.getInstance()
+        if not ciPlatform.getCiUrl():
+            return
 
-    def getCiBuildNumber(self, tag):
-        return tag.split(".")[-1]
-
-    def generateJenkinsChanges(self, pageDir):
-        cacheDir = os.path.join(os.path.dirname(pageDir), "jenkins_changes")
         bgColour = self.colourFinder.find("changes_header_bg")
         row = [HTMLgen.TD("Changes", bgcolor=bgColour)]
         hasData = False
         prevTag = None
         for tag in self.tags:
-            allChanges = self.findJenkinsChanges(prevTag, tag, cacheDir)
+            allChanges = ciPlatform.findChanges(prevTag, tag, pageDir, self.getConfigValue)
             cont = HTMLgen.Container()
             aborted = False
             for i, (authorOrMessage, target, bugs) in enumerate(allChanges):
@@ -765,38 +738,33 @@ class TestTable:
             runNameDirs.add(os.path.join(os.path.dirname(os.path.dirname(dir)), "run_names"))
         return runNameDirs
 
-    def getRunEnv(self, runEnv, key):
-        return runEnv.get(key, os.getenv(key))
+    def getCIPlatformForTableHead(self, runNameDirs, tag):
+        platformEnv = {}
+        platformEnv.update(os.environ)
+        runEnv = getEnvironmentFromRunFiles(runNameDirs, tag)
+        platformEnv.update(runEnv)
+        ciPlatform = CIPlatform.getInstance(platformEnv)
+        ciPlatform.setCurrentTag(tag)
+        return ciPlatform
 
-    def getCiLinkData(self, runEnv, buildNumber):
-        jenkinsUrl = self.getRunEnv(runEnv, "JENKINS_URL")
-        if jenkinsUrl:
-            target = os.path.join(jenkinsUrl, "job", self.getRunEnv(runEnv, "JOB_NAME"), buildNumber)
-            title = "Jenkins " + buildNumber
-        else:
-            azdoUrl = self.getRunEnv(runEnv, "SYSTEM_TEAMFOUNDATIONSERVERURI")
-            if azdoUrl:
-                project = urllib.parse.quote(self.getRunEnv(runEnv, "SYSTEM_TEAMPROJECT"))
-                target = os.path.join(azdoUrl, project, "_build", "results?buildId=" + self.getRunEnv(runEnv, "BUILD_BUILDID"))   
-                title = "AZ DevOps " + self.getRunEnv(runEnv, "BUILD_BUILDNUMBER")
-        return title, target
 
     def generateTableHead(self, repositoryDirs):
         head = [HTMLgen.TH("Test")]
-        ciUrl = os.getenv("JENKINS_URL") or os.getenv("SYSTEM_TEAMFOUNDATIONSERVERURI")
-        runNameDirs = self.getRunNameDirs(repositoryDirs) if ciUrl else []
+        runNameDirs = self.getRunNameDirs(repositoryDirs)
         for tag in self.tags:
+            ciPlatform = self.getCIPlatformForTableHead(runNameDirs, tag)
+            ciUrl = ciPlatform.getCiUrl()
             tagColour = self.findTagColour(tag)
             linkTarget = getDetailPageName(self.pageVersion, tag)
             linkText = HTMLgen.Font(getDisplayText(tag), color=tagColour)
-            buildNumber = self.getCiBuildNumber(tag)
+            buildNumber = ciPlatform.getBuildNumber()
             if ciUrl and buildNumber.isdigit():
-                runEnv = getEnvironmentFromRunFiles(runNameDirs, tag)
                 container = HTMLgen.Container()
-                tooltip = jenkinschanges.getTimestamp(buildNumber)
+                tooltip = ciPlatform.getJobTooltip()
                 container.append(HTMLgen.Href(linkTarget, linkText, title=tooltip))
                 container.append(HTMLgen.BR())
-                ciTitle, ciTarget = self.getCiLinkData(runEnv, buildNumber)
+                ciTitle = ciPlatform.getJobTitle()
+                ciTarget = ciPlatform.getJobUrl()
                 ciText = HTMLgen.Emphasis(HTMLgen.Font("(" + ciTitle + ")", size=1))
                 container.append(HTMLgen.Href(ciTarget, ciText, title=tooltip))
                 head.append(HTMLgen.TH(container))


### PR DESCRIPTION
We are planning to move away from Jenkins into Gitlab runners instead. The support for CI platforms seemed to be rather spread out so I took a shot at trying to gather it all in one place to simplify it. Adding new platforms should be as simple as subclassing `CIPlatform` now. I will add tests to the selftests for the Gitlab parts as well but wanted to get initial thoughts from you first.