### PR TITLE
Avoid setting environment variable with no key

### DIFF
--- a/texttestlib/default/__init__.py
+++ b/texttestlib/default/__init__.py
@@ -503,7 +503,7 @@ class Config:
     def getWriteDirectories(self, app):
         rootDir = self.optionMap.setPathFromOptionsOrEnv("TEXTTEST_TMP", app.getConfigValue("default_texttest_tmp"))  # Location of temporary files from test runs
         if not os.path.isdir(rootDir) and not self.hasWritePermission(os.path.dirname(rootDir)):
-            rootDir = self.optionMap.setPathFromOptionsOrEnv("", "$TEXTTEST_PERSONAL_CONFIG/tmp")
+            rootDir = self.optionMap.normalisePath(os.path.expandvars("$TEXTTEST_PERSONAL_CONFIG/tmp"))
         writeDir = os.path.join(rootDir, self.getWriteDirectoryName(app))
         localRootDir = self.optionMap.getPathFromOptionsOrEnv("TEXTTEST_LOCAL_TMP", app.getConfigValue("default_texttest_local_tmp")) # Location of temporary files on local disk from test runs. Defaults to value of TEXTTEST_TMP
         if localRootDir:


### PR DESCRIPTION
If the normal `TEXTTEST_TMP` directory is not available texttest has a fallback to the personal config directory.
It gets this directory by calling the function `setPathFromOptionsOrEnv`, since the first parameter is an empty string this function tries to set the resulting path as a environment variable... Since at least Python 3.8 this is not allowed.

I think and hope that setting the path in a variable without name was never the intention with the code.
The solution I implemented instead does the other parts of the `setPathFromOptionsOrEnv` function.


