### PR TITLE
add Python 3.13 to CI

### DIFF
--- a/.github/workflows/self-test.yml
+++ b/.github/workflows/self-test.yml
@@ -15,7 +15,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest]
         build_env: [native]
-        python: [3.9, '3.10', 3.11, 3.12]
+        python: [3.9, '3.10', 3.11, 3.12, 3.13]
         include:
           - os: windows-latest
             build_env: msys


### PR DESCRIPTION
Requires https://github.com/texttest/texttest/pull/135 to be merged first.