### PR TITLE
Make performance metrics more customizable

### DIFF
--- a/texttestlib/default/console.py
+++ b/texttestlib/default/console.py
@@ -23,7 +23,7 @@ class TextDisplayResponder(plugins.Responder):
             return ""
         elif category == "bug":
             return "Known Bugs"
-        elif category.startswith("faster") or category.startswith("slower") or category == "smaller" or category == "larger":
+        elif category.startswith("faster") or category.startswith("slower") or category.startswith("smaller") or category.startswith("larger"):
             return "Performance Differences"
         elif category in ["killed", "unrunnable", "cancelled", "abandoned"]:
             return "Incomplete"


### PR DESCRIPTION
The aim of this pull request is to make the performance metric "larger" and "smaller" more customizable.

In our FleetOpt texttest configuration (software development team in jeppesen), we have introduced new performance descriptors following the naming pattern smaller <word> and larger <word>. When using this convention, texttest reports test that has performance difference of type smaller <word> or larger <word> as failure. If the descriptors slower and faster are being used instead, faster <word> or slower word>, then texttest reports the test as performance difference (as it should be) instead of failure. 