### PR TITLE
Fix call from actionrunner

### DIFF
--- a/texttestlib/default/actionrunner.py
+++ b/texttestlib/default/actionrunner.py
@@ -252,7 +252,7 @@ class ApplicationRunner:
         self.suitesSetUp[suite] = []
 
     def getActionSequence(self):
-        actionSequenceFromConfig = self.testSuite.app.getActionSequence()
+        actionSequenceFromConfig = self.testSuite.app.getActionSequence(self.testSuite.app)
         actionSequence = []
         # Collapse lists and remove None actions
         for action in actionSequenceFromConfig:


### PR DESCRIPTION
This currently works due to [ConfigurationCall](https://github.com/texttest/texttest/blob/master/texttestlib/testmodel.py#L1497) helping with correcting the call but it makes more sense to get it right from the beginning. `getActionSequence` have looked like for over 10+ years (since [8665520231600c35744](https://github.com/texttest/texttest/commit/8665520231600c3574436d389dcb9479c9406522)) so it feels like it is time to get it right.